### PR TITLE
add `gcsafe` pragma to methods

### DIFF
--- a/src/termui/buffer.nim
+++ b/src/termui/buffer.nim
@@ -57,19 +57,19 @@ class TerminalBuffer:
     
 
     ## Set background color
-    method setBackgroundColor(ansiStyle : string = "") =
+    method setBackgroundColor(ansiStyle : string = "") {.gcsafe.} =
         this.bgColor = ansiStyle
         this.ansiStyle = this.bgColor & this.fgColor & this.fontStyle
 
 
     ## Set foreground color
-    method setForegroundColor(ansiStyle : string = "") =
+    method setForegroundColor(ansiStyle : string = "") {.gcsafe.} =
         this.fgColor = ansiStyle
         this.ansiStyle = this.bgColor & this.fgColor & this.fontStyle
 
 
     ## Set font style
-    method setFontStyle(ansiStyle : string = "") =
+    method setFontStyle(ansiStyle : string = "") {.gcsafe.} =
         this.fontStyle = ansiStyle
         this.ansiStyle = this.bgColor & this.fgColor & this.fontStyle
 
@@ -77,7 +77,7 @@ class TerminalBuffer:
     ## Throw an error if we are not on the same thread that first modified this buffer. This
     ## is due to nim's Seq type being entirely un-thread-safe, as in the data literally gets
     ## corrupted just by accessing it from another thread which added items to it!
-    method checkThread() =
+    method checkThread() {.gcsafe.} =
 
         # Only if thread support is enabled...
         when compileOption("threads"):
@@ -95,7 +95,7 @@ class TerminalBuffer:
 
 
     ## Clear all data
-    method clear() =
+    method clear() {.gcsafe.} =
 
         # Check thread
         this.checkThread()
@@ -108,7 +108,7 @@ class TerminalBuffer:
 
 
     ## Get character at position
-    method charAt(x : int, y : int, screenBuffer : bool = false) : Character =
+    method charAt(x : int, y : int, screenBuffer : bool = false) : Character {.gcsafe.} =
 
         # Check thread
         this.checkThread()
@@ -130,13 +130,13 @@ class TerminalBuffer:
 
 
     ## Move cursor to position
-    method moveTo(x, y: int) =
+    method moveTo(x, y: int) {.gcsafe.} =
         this.textCursorX = x
         this.textCursorY = y
 
 
     ## Check if a specific line is empty
-    method isLineEmpty(line : int) : bool =
+    method isLineEmpty(line : int) : bool {.gcsafe.} =
 
         # Check thread
         this.checkThread()
@@ -151,7 +151,7 @@ class TerminalBuffer:
 
 
     ## Draw text
-    method write(text : string) =
+    method write(text : string) {.gcsafe.} =
 
         # Check thread
         this.checkThread()
@@ -178,7 +178,7 @@ class TerminalBuffer:
 
 
     ## Draw the change from the screen buffer
-    method draw() =
+    method draw() {.gcsafe.} =
 
         # Check thread
         this.checkThread()
@@ -284,7 +284,7 @@ class TerminalBuffer:
 
 
     ## Clean up the terminal for standard output again
-    method finish() =
+    method finish() {.gcsafe.} =
 
         # Show cursor in case it was hidden
         if not this.cursorVisible:

--- a/src/termui/progressbar.nim
+++ b/src/termui/progressbar.nim
@@ -37,7 +37,7 @@ class TermuiProgressBar of TermuiWidget:
 
 
     ## Render
-    method render() =
+    method render() {.gcsafe.} =
 
         # Clear the buffer
         this.buffer.clear()
@@ -88,7 +88,7 @@ class TermuiProgressBar of TermuiWidget:
 
 
     ## Update text
-    method update(progress : float, text : string = "") =
+    method update(progress : float, text : string = "") {.gcsafe.} =
 
         # Update text
         this.progress = progress
@@ -100,7 +100,7 @@ class TermuiProgressBar of TermuiWidget:
 
 
     ## Finish with completion
-    method complete(text : string = "") =
+    method complete(text : string = "") {.gcsafe.} =
 
         # Update text
         if text.len() > 0:
@@ -112,7 +112,7 @@ class TermuiProgressBar of TermuiWidget:
         
 
     ## Finish with warning
-    method warn(text : string = "") =
+    method warn(text : string = "") {.gcsafe.} =
 
         # Update text
         if text.len() > 0:
@@ -124,7 +124,7 @@ class TermuiProgressBar of TermuiWidget:
         
 
     ## Finish with error
-    method fail(text : string = "") =
+    method fail(text : string = "") {.gcsafe.} =
 
         # Update text
         if text.len() > 0:

--- a/src/termui/widget.nim
+++ b/src/termui/widget.nim
@@ -54,13 +54,13 @@ class TermuiWidgetBase:
     var buffer : TerminalBuffer = TerminalBuffer.init()
 
     ## Render function, subclasses should override this and update the buffer
-    method render() = discard
+    method render() {.gcsafe.} = discard
 
     ## Called when the user inputs something on the keyboard while we are blocking
-    method onInput(event : KeyboardEvent) = discard
+    method onInput(event : KeyboardEvent) {.gcsafe.} = discard
 
     ## Start rendering. This will block until isBlocking becomes false. Subclasses should make it false.
-    method start() =
+    method start() {.gcsafe.} =
 
         # Enable ANSI support for Windows terminals
         enableAnsiOnWindowsConsole()
@@ -100,7 +100,7 @@ class TermuiWidgetBase:
 
     ## Render the next frame. This can be called either on the main thread or a background thread, depending
     ## if renderInBackgroundContinuously is true or not.
-    method renderFrame() = 
+    method renderFrame() {.gcsafe.} = 
 
         # Allow subclass to update the buffer
         this.render()
@@ -110,7 +110,7 @@ class TermuiWidgetBase:
 
 
     ## Finish this widget
-    method finish() =
+    method finish() {.gcsafe.} =
 
         # Stop the loop
         this.isFinished = true
@@ -134,7 +134,7 @@ class TermuiWidgetBase:
 
 
     ## Starts the background thread. Called on the main thread.
-    method startThread() = 
+    method startThread() {.gcsafe.} = 
     
         # Not supported! Let's just draw one iteration now
         this.renderFrame()
@@ -158,7 +158,7 @@ else:
         var thread : Thread[pointer]
 
         ## Starts the backgound thread. Called on the main thread.
-        method startThread() =
+        method startThread() {.gcsafe.} =
 
             # HACK: Lock it so the instance doesn't get garbage collected. Without this, it is giving a SIGSEGV at random places AFTER the widget
             # is already completed and the thread ended! I don't understand it at all.
@@ -175,7 +175,7 @@ else:
 
 
         ## Runs on a background thread
-        method runThread() {.thread.} =
+        method runThread() {.thread, gcsafe.} =
 
             # Continually re-render
             while true:
@@ -198,7 +198,7 @@ else:
 
 
         ## Finish this widget
-        method finish() =
+        method finish() {.gcsafe.} =
 
             # Kill the thread, wait for it to finish
             if this.redrawMode == TermuiRedrawInThread:


### PR DESCRIPTION
I'm not sure if this is a Nim 2.0 error, but tests fail with this error:

`Error: Base method '<METHOD>' requires explicit '{.gcsafe.}' to be GC-safe`

I added the `gcsafe` pragma to remove this error